### PR TITLE
Added support for belgian BIS-number

### DIFF
--- a/src/Core/Europe/Belgium/BelgiumCitizenInformationExtractor.php
+++ b/src/Core/Europe/Belgium/BelgiumCitizenInformationExtractor.php
@@ -25,12 +25,18 @@ class BelgiumCitizenInformationExtractor implements CitizenInformationExtractor
             throw new InvalidIdException();
         }
 
-        $gender = $this->getGender($id);
-        $dateOfBirth = $this->getDateOfBirth($id);
-
         $citizen = new Citizen();
-        $citizen->setGender($gender);
-        $citizen->setDateOfBirth($dateOfBirth);
+
+        // BIS numbers: month + 20 = gender unknown, month + 40 = gender known
+        // Regular NRN: always has gender
+        if (!$this->isBisNumber($id) || $this->isBisGenderKnown($id)) {
+            $citizen->setGender($this->getGender($id));
+        }
+
+        // Extract DOB if birthdate is known (month is not 00, 20, or 40)
+        if (!$this->isBirthdateUnknown($id)) {
+            $citizen->setDateOfBirth($this->getDateOfBirth($id));
+        }
 
         return $citizen;
     }
@@ -40,7 +46,31 @@ class BelgiumCitizenInformationExtractor implements CitizenInformationExtractor
         return str_replace(['-', ' ', '.'], '', $id);
     }
 
-    private function getGender(int $id): Gender
+    private function isBisNumber(string $id): bool
+    {
+        $month = (int) substr($id, 2, 2);
+
+        return $month > 12;
+    }
+
+    private function isBisGenderKnown(string $id): bool
+    {
+        $month = (int) substr($id, 2, 2);
+
+        // Month + 40 means gender is known, month + 20 means gender is unknown
+        return $month >= 40;
+    }
+
+    private function isBirthdateUnknown(string $id): bool
+    {
+        $month = (int) substr($id, 2, 2);
+
+        // For BIS numbers only: month 20 or 40 means birthdate is unknown
+        // Regular NRN with month 00 still extracts DOB (defaults to January)
+        return $month === 20 || $month === 40;
+    }
+
+    private function getGender(string $id): Gender
     {
         return (substr($id, 6, 3) % 2) ? Gender::Male : Gender::Female;
     }
@@ -53,6 +83,13 @@ class BelgiumCitizenInformationExtractor implements CitizenInformationExtractor
         $year = (int) $year;
         $month = (int) $month;
         $day = (int) $day;
+
+        // BIS numbers have 20 or 40 added to the month
+        if ($month >= 40) {
+            $month -= 40;
+        } elseif ($month >= 20) {
+            $month -= 20;
+        }
 
         // use first day or month if unknown
         $month = $month === 0 ? 1 : $month;

--- a/src/Core/Europe/Belgium/BelgiumIdValidator.php
+++ b/src/Core/Europe/Belgium/BelgiumIdValidator.php
@@ -84,6 +84,13 @@ class BelgiumIdValidator implements IdValidator
         $month = (int) $month;
         $day = (int) $day;
 
+        // BIS numbers have 20 or 40 added to the month
+        if ($month >= 40) {
+            $month -= 40;
+        } elseif ($month >= 20) {
+            $month -= 20;
+        }
+
         $month = $month === 0 ? 1 : $month;
         $day = $day === 0 ? 1 : $day;
 

--- a/src/Models/Citizen.php
+++ b/src/Models/Citizen.php
@@ -13,21 +13,21 @@ class Citizen
      *
      * @var Gender|null
      */
-    private ?Gender $gender;
+    private ?Gender $gender = null;
 
     /**
      * The date of birth as a DateTime object.
      *
      * @var DateTime|null
      */
-    private ?DateTime $dateOfBirth;
+    private ?DateTime $dateOfBirth = null;
 
     /**
      * The place of birth as a string.
      *
      * @var string|null
      */
-    private ?string $placeOfBirth;
+    private ?string $placeOfBirth = null;
 
     /**
      * Get the citizen's gender.

--- a/tests/Feature/Europe/BelgiumTest.php
+++ b/tests/Feature/Europe/BelgiumTest.php
@@ -11,6 +11,7 @@ use Reducktion\Socrates\Tests\Feature\FeatureTest;
 class BelgiumTest extends FeatureTest
 {
     private array $people;
+    private array $bisNumbers;
     private array $invalidIds;
 
     public function setUp(): void
@@ -48,6 +49,29 @@ class BelgiumTest extends FeatureTest
                 'dob' => new DateTime('1940-01-01'),
                 'age' => $this->calculateAge(new DateTime('1940-01-01')),
             ]
+        ];
+
+        $this->bisNumbers = [
+            'dobAndGenderUnknown1' => [
+                'id' => '11200274580',
+                'gender' => null,
+                'dob' => null,
+            ],
+            'dobAndGenderUnknown2' => [
+                'id' => '00200203376',
+                'gender' => null,
+                'dob' => null,
+            ],
+            'dobUnknownGenderKnown' => [
+                'id' => '00400048320',
+                'gender' => Gender::Male,
+                'dob' => null,
+            ],
+            'dobAndGenderKnown' => [
+                'id' => '00421090786',
+                'gender' => Gender::Male,
+                'dob' => new DateTime('2000-02-10'),
+            ],
         ];
 
         $this->invalidIds = [
@@ -93,5 +117,24 @@ class BelgiumTest extends FeatureTest
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->getCitizenDataFromId('12.12.12-1323.32', Country::Belgium);
+    }
+
+    public function test_bis_number_validation(): void
+    {
+        foreach ($this->bisNumbers as $bisNumber) {
+            self::assertTrue(
+                $this->socrates->validateId($bisNumber['id'], Country::Belgium)
+            );
+        }
+    }
+
+    public function test_bis_number_extraction(): void
+    {
+        foreach ($this->bisNumbers as $bisNumber) {
+            $citizen = $this->socrates->getCitizenDataFromId($bisNumber['id'], Country::Belgium);
+
+            self::assertEquals($bisNumber['gender'], $citizen->getGender());
+            self::assertEquals($bisNumber['dob'], $citizen->getDateOfBirth());
+        }
     }
 }


### PR DESCRIPTION
Hi,

I am opening this PR since in Belgium it is possible if you are a foreign worker, you also get a ISNZ-number but changed depending on the available data.
More information about these types of numbers can be found here: https://testdatagenerator.bignited.be/
(I tried to find a clear overview on a government website but they complicated it too much, the link above explains it super clear)

I had to change the citizen model aswell as it is not always possible to extract a DOB or gender from the BIS-numbers.