### PR TITLE
Chore: use data providers in tests

### DIFF
--- a/src/Models/Citizen.php
+++ b/src/Models/Citizen.php
@@ -56,11 +56,7 @@ class Citizen
      */
     public function getAge(): ?int
     {
-        if (!$this->dateOfBirth) {
-            throw new UnsupportedOperationException('Citizen date of birth is null.');
-        }
-
-        return (new DateTime())->diff($this->dateOfBirth)->y;
+        return $this->dateOfBirth ? new DateTime()->diff($this->dateOfBirth)->y : null;
     }
 
     /**

--- a/tests/Feature/Europe/AlbaniaTest.php
+++ b/tests/Feature/Europe/AlbaniaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,83 +11,94 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class AlbaniaTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'bardhana' => [
-                'nid' => 'I05101999I',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1980-01-01'),
-                'age' => $this->calculateAge(new DateTime('1980-01-01')),
+                'person' => [
+                    'nid' => 'I05101999I',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1980-01-01'),
+                    'age' => self::calculateAge(new DateTime('1980-01-01')),
+                ],
             ],
             'shufti' => [
-                'nid' => 'I90201535E',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1989-02-01'),
-                'age' => $this->calculateAge(new DateTime('1989-02-01')),
+                'person' => [
+                    'nid' => 'I90201535E',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1989-02-01'),
+                    'age' => self::calculateAge(new DateTime('1989-02-01')),
+                ],
             ],
             'shyqe' => [
-                'nid' => 'J45423004V',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1994-04-23'),
-                'age' => $this->calculateAge(new DateTime('1994-04-23')),
+                'person' => [
+                    'nid' => 'J45423004V',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1994-04-23'),
+                    'age' => self::calculateAge(new DateTime('1994-04-23')),
+                ],
             ],
             'elseid' => [
-                'nid' => 'H71211672R',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1977-12-11'),
-                'age' => $this->calculateAge(new DateTime('1977-12-11')),
+                'person' => [
+                    'nid' => 'H71211672R',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1977-12-11'),
+                    'age' => self::calculateAge(new DateTime('1977-12-11')),
+                ],
             ],
             'hasna' => [
-                'nid' => 'I85413200A',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1988-04-13'),
-                'age' => $this->calculateAge(new DateTime('1988-04-13')),
+                'person' => [
+                    'nid' => 'I85413200A',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1988-04-13'),
+                    'age' => self::calculateAge(new DateTime('1988-04-13')),
+                ],
             ],
-        ];
-
-        $this->invalidIds = [
-            'I05101999Q',
-            'J45423004Y',
-            'I85413200J',
-            'I90201535M',
-            'H71211672A',
         ];
     }
 
-    public function test_extract_behaviour(): void
+    public static function invalidIdsDataProvider(): array
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['nid'], Country::Albania);
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-        }
+        return [
+            ['I05101999Q'],
+            ['J45423004Y'],
+            ['I85413200J'],
+            ['I90201535M'],
+            ['H71211672A'],
+        ];
+    }
+
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
+    {
+        $citizen = $this->socrates->getCitizenDataFromId($person['nid'], Country::Albania);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
 
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->getCitizenDataFromId('I051019992I', Country::Albania);
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['nid'], Country::Albania)
-            );
-        }
+        self::assertTrue(
+            $this->socrates->validateId($person['nid'], Country::Albania)
+        );
+    }
 
-        foreach ($this->invalidIds as $invalidId) {
-            self::assertFalse(
-                $this->socrates->validateId($invalidId, Country::Albania)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse(
+            $this->socrates->validateId($invalidId, Country::Albania)
+        );
+    }
 
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('I0785101999I', Country::Albania);

--- a/tests/Feature/Europe/AlbaniaTest.php
+++ b/tests/Feature/Europe/AlbaniaTest.php
@@ -75,26 +75,18 @@ class AlbaniaTest extends FeatureTestCase
         self::assertEquals($person['gender'], $citizen->getGender());
         self::assertEquals($person['dob'], $citizen->getDateOfBirth());
         self::assertEquals($person['age'], $citizen->getAge());
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('I051019992I', Country::Albania);
     }
 
     #[DataProvider('peopleDataProvider')]
     public function test_validation_with_valid_ids_passes(array $person): void
     {
-        self::assertTrue(
-            $this->socrates->validateId($person['nid'], Country::Albania)
-        );
+        self::assertTrue($this->socrates->validateId($person['nid'], Country::Albania));
     }
 
     #[DataProvider('invalidIdsDataProvider')]
     public function test_validation_with_invalid_ids_fails(string $invalidId): void
     {
-        self::assertFalse(
-            $this->socrates->validateId($invalidId, Country::Albania)
-        );
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Albania));
     }
 
     public function test_validation_using_ids_with_invalid_length_throw_exception(): void

--- a/tests/Feature/Europe/BelgiumTest.php
+++ b/tests/Feature/Europe/BelgiumTest.php
@@ -108,26 +108,18 @@ class BelgiumTest extends FeatureTestCase
         self::assertEquals($person['gender'], $citizen->getGender());
         self::assertEquals($person['dob'], $citizen->getDateOfBirth());
         self::assertEquals($person['age'], $citizen->getAge());
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('12.12.12-1323.32', Country::Belgium);
     }
 
     #[DataProvider('peopleDataProvider')]
     public function test_validation_with_valid_ids_passes(array $person): void
     {
-        self::assertTrue(
-            $this->socrates->validateId($person['id'], Country::Belgium)
-        );
+        self::assertTrue($this->socrates->validateId($person['id'], Country::Belgium));
     }
 
     #[DataProvider('invalidIdsDataProvider')]
     public function test_validation_with_invalid_ids_fails(string $invalidId): void
     {
-        self::assertFalse(
-            $this->socrates->validateId($invalidId, Country::Belgium)
-        );
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Belgium));
     }
 
     public function test_validation_using_ids_with_invalid_length_throw_exception(): void

--- a/tests/Feature/Europe/BelgiumTest.php
+++ b/tests/Feature/Europe/BelgiumTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,131 +11,129 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class BelgiumTest extends FeatureTestCase
 {
-    private array $people;
-    private array $bisNumbers;
-    private array $invalidIds;
-
-    public function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'shahin' => [
-                'id' => '93.05.18-223.61',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1993-05-18'),
-                'age' => $this->calculateAge(new DateTime('1993-05-18')),
+                'person' => [
+                    'id' => '93.05.18-223.61',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1993-05-18'),
+                    'age' => self::calculateAge(new DateTime('1993-05-18')),
+                ],
             ],
             'naoual' => [
-                'id' => '730111-361-73',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1973-01-11'),
-                'age' => $this->calculateAge(new DateTime('1973-01-11')),
+                'person' => [
+                    'id' => '730111-361-73',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1973-01-11'),
+                    'age' => self::calculateAge(new DateTime('1973-01-11')),
+                ],
             ],
             'xavi' => [
-                'id' => '75.12.05-137.14',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1975-12-05'),
-                'age' => $this->calculateAge(new DateTime('1975-12-05')),
+                'person' => [
+                    'id' => '75.12.05-137.14',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1975-12-05'),
+                    'age' => self::calculateAge(new DateTime('1975-12-05')),
+                ],
             ],
             'kurt' => [
-                'id' => '71.09.07-213.64',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1971-09-07'),
-                'age' => $this->calculateAge(new DateTime('1971-09-07')),
+                'person' => [
+                    'id' => '71.09.07-213.64',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1971-09-07'),
+                    'age' => self::calculateAge(new DateTime('1971-09-07')),
+                ],
             ],
             'mark' => [
-                'id' => '40.00.01-001.33',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1940-01-01'),
-                'age' => $this->calculateAge(new DateTime('1940-01-01')),
-            ]
-        ];
-
-        $this->bisNumbers = [
+                'person' => [
+                    'id' => '40.00.01-001.33',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1940-01-01'),
+                    'age' => self::calculateAge(new DateTime('1940-01-01')),
+                ],
+            ],
+            // BIS numbers
             'dobAndGenderUnknown1' => [
-                'id' => '11200274580',
-                'gender' => null,
-                'dob' => null,
+                'person' => [
+                    'id' => '11200274580',
+                    'gender' => null,
+                    'dob' => null,
+                ],
             ],
             'dobAndGenderUnknown2' => [
-                'id' => '00200203376',
-                'gender' => null,
-                'dob' => null,
+                'person' => [
+                    'id' => '00200203376',
+                    'gender' => null,
+                    'dob' => null,
+                ],
             ],
             'dobUnknownGenderKnown' => [
-                'id' => '00400048320',
-                'gender' => Gender::Male,
-                'dob' => null,
+                'person' => [
+                    'id' => '00400048320',
+                    'gender' => Gender::Male,
+                    'dob' => null,
+                ],
             ],
             'dobAndGenderKnown' => [
-                'id' => '00421090786',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('2000-02-10'),
+                'person' => [
+                    'id' => '00421090786',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('2000-02-10'),
+                    'age' => self::calculateAge(new DateTime('2000-02-10')),
+                ],
             ],
         ];
+    }
 
-        $this->invalidIds = [
-            '12.12.12-132.32',
-            '97.12.03-123.12',
-            '01.06.18-468.99',
-            '64.04.09-874.43',
-            '12.10.23-954.11',
-            '00.08.24-282.48', // invalid age
-            '01.11.16-000.06', // invalid sequence number
-            '01.11.16-999.74'  // invalid sequence number
+    public static function invalidIdsDataProvider(): array
+    {
+        return [
+            ['12.12.12-132.32'],
+            ['97.12.03-123.12'],
+            ['01.06.18-468.99'],
+            ['64.04.09-874.43'],
+            ['12.10.23-954.11'],
+            ['00.08.24-282.48'], // invalid age
+            ['01.11.16-000.06'], // invalid sequence number
+            ['01.11.16-999.74'], // invalid sequence number
         ];
     }
 
-    public function test_extract_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['id'], Country::Belgium);
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-        }
+        $citizen = $this->socrates->getCitizenDataFromId($person['id'], Country::Belgium);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
 
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->getCitizenDataFromId('12.12.12-1323.32', Country::Belgium);
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['id'], Country::Belgium)
-            );
-        }
+        self::assertTrue(
+            $this->socrates->validateId($person['id'], Country::Belgium)
+        );
+    }
 
-        foreach ($this->invalidIds as $id) {
-            self::assertFalse(
-                $this->socrates->validateId($id, Country::Belgium)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse(
+            $this->socrates->validateId($invalidId, Country::Belgium)
+        );
+    }
 
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->getCitizenDataFromId('12.12.12-1323.32', Country::Belgium);
-    }
-
-    public function test_bis_number_validation(): void
-    {
-        foreach ($this->bisNumbers as $bisNumber) {
-            self::assertTrue(
-                $this->socrates->validateId($bisNumber['id'], Country::Belgium)
-            );
-        }
-    }
-
-    public function test_bis_number_extraction(): void
-    {
-        foreach ($this->bisNumbers as $bisNumber) {
-            $citizen = $this->socrates->getCitizenDataFromId($bisNumber['id'], Country::Belgium);
-
-            self::assertEquals($bisNumber['gender'], $citizen->getGender());
-            self::assertEquals($bisNumber['dob'], $citizen->getDateOfBirth());
-        }
     }
 }

--- a/tests/Feature/Europe/BosniaAndHerzegovinaTest.php
+++ b/tests/Feature/Europe/BosniaAndHerzegovinaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,90 +11,92 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class BosniaAndHerzegovinaTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'Naser' => [
-                'jmbg' => '1502957172694',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1957-02-15'),
-                'age' => $this->calculateAge(new DateTime('1957-02-15')),
-                'pob' => 'Sarajevo - Bosnia and Herzegovina'
+                'person' => [
+                    'jmbg' => '1502957172694',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1957-02-15'),
+                    'age' => self::calculateAge(new DateTime('1957-02-15')),
+                    'pob' => 'Sarajevo - Bosnia and Herzegovina'
+                ],
             ],
             'Imran' => [
-                'jmbg' => '2508995191483',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1995-08-25'),
-                'age' => $this->calculateAge(new DateTime('1995-08-25')),
-                'pob' => 'Zenica - Bosnia and Herzegovina'
+                'person' => [
+                    'jmbg' => '2508995191483',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1995-08-25'),
+                    'age' => self::calculateAge(new DateTime('1995-08-25')),
+                    'pob' => 'Zenica - Bosnia and Herzegovina'
+                ],
             ],
             'Ajdin' => [
-                'jmbg' => '1012980163603',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1980-12-10'),
-                'age' => $this->calculateAge(new DateTime('1980-12-10')),
-                'pob' => 'Prijedor - Bosnia and Herzegovina'
+                'person' => [
+                    'jmbg' => '1012980163603',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1980-12-10'),
+                    'age' => self::calculateAge(new DateTime('1980-12-10')),
+                    'pob' => 'Prijedor - Bosnia and Herzegovina'
+                ],
             ],
             'Merjem' => [
-                'jmbg' => '1310963145538',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1963-10-13'),
-                'age' => $this->calculateAge(new DateTime('1963-10-13')),
-                'pob' => 'Livno - Bosnia and Herzegovina'
+                'person' => [
+                    'jmbg' => '1310963145538',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1963-10-13'),
+                    'age' => self::calculateAge(new DateTime('1963-10-13')),
+                    'pob' => 'Livno - Bosnia and Herzegovina'
+                ],
             ],
             'Eman' => [
-                'jmbg' => '1806998154160',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1998-06-18'),
-                'age' => $this->calculateAge(new DateTime('1998-06-18')),
-                'pob' => 'Mostar - Bosnia and Herzegovina'
-            ]
-        ];
-
-        $this->invalidIds = [
-            '1108291065212',
-            '2808928401264',
-            '2007950274591',
-            '2801826817261',
-            '1012999121239',
+                'person' => [
+                    'jmbg' => '1806998154160',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1998-06-18'),
+                    'age' => self::calculateAge(new DateTime('1998-06-18')),
+                    'pob' => 'Mostar - Bosnia and Herzegovina'
+                ],
+            ],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    public static function invalidIdsDataProvider(): array
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['jmbg'], Country::BosniaHerzegovina);
-
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
-        }
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('010597850041', Country::BosniaHerzegovina);
+        return [
+            ['1108291065212'],
+            ['2808928401264'],
+            ['2007950274591'],
+            ['2801826817261'],
+            ['1012999121239'],
+        ];
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['jmbg'], Country::BosniaHerzegovina)
-            );
-        }
+        $citizen = $this->socrates->getCitizenDataFromId($person['jmbg'], Country::BosniaHerzegovina);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
+        self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+    }
 
-        foreach ($this->invalidIds as $jmbg) {
-            self::assertFalse(
-                $this->socrates->validateId($jmbg, Country::BosniaHerzegovina)
-            );
-        }
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
+    {
+        self::assertTrue($this->socrates->validateId($person['jmbg'], Country::BosniaHerzegovina));
+    }
 
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::BosniaHerzegovina));
+    }
+
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('1012999121', Country::BosniaHerzegovina);

--- a/tests/Feature/Europe/BulgariaTest.php
+++ b/tests/Feature/Europe/BulgariaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,89 +11,94 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class BulgariaTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'Andrei' => [
-                'egn' => '7523169263',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1875-03-16'),
-                'age' => $this->calculateAge(new DateTime('1875-03-16')),
+                'person' => [
+                    'egn' => '7523169263',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1875-03-16'),
+                    'age' => self::calculateAge(new DateTime('1875-03-16')),
+                ],
             ],
             'Lyuben' => [
-                'egn' => '8032056031',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1880-12-05'),
-                'age' => $this->calculateAge(new DateTime('1880-12-05')),
+                'person' => [
+                    'egn' => '8032056031',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1880-12-05'),
+                    'age' => self::calculateAge(new DateTime('1880-12-05')),
+                ],
             ],
             'Bilyana' => [
-                'egn' => '8001010008',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1980-01-01'),
-                'age' => $this->calculateAge(new DateTime('1980-01-01')),
+                'person' => [
+                    'egn' => '8001010008',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1980-01-01'),
+                    'age' => self::calculateAge(new DateTime('1980-01-01')),
+                ],
             ],
             'Kalina' => [
-                'egn' => '7501020018',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1975-01-02'),
-                'age' => $this->calculateAge(new DateTime('1975-01-02')),
+                'person' => [
+                    'egn' => '7501020018',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1975-01-02'),
+                    'age' => self::calculateAge(new DateTime('1975-01-02')),
+                ],
             ],
             'Nedyalko' => [
-                'egn' => '7552010005',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('2075-12-01'),
-                'age' => $this->calculateAge(new DateTime('2075-12-01')),
+                'person' => [
+                    'egn' => '7552010005',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('2075-12-01'),
+                    'age' => self::calculateAge(new DateTime('2075-12-01')),
+                ],
             ],
             'Tsveta' => [
-                'egn' => '7542011030',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('2075-02-01'),
-                'age' => $this->calculateAge(new DateTime('2075-02-01')),
+                'person' => [
+                    'egn' => '7542011030',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('2075-02-01'),
+                    'age' => self::calculateAge(new DateTime('2075-02-01')),
+                ],
             ]
         ];
+    }
 
-        $this->invalidIds = [
-            '7542021030',
-            '8002560008',
-            '3542027033',
-            '6002567498',
-            '7542039611',
+    public static function invalidIdsDataProvider(): array
+    {
+        return [
+            ['7542021030'],
+            ['8002560008'],
+            ['3542027033'],
+            ['6002567498'],
+            ['7542039611'],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['egn'], Country::Bulgaria);
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-        }
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('754201103', Country::Bulgaria);
+        $citizen = $this->socrates->getCitizenDataFromId($person['egn'], Country::Bulgaria);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['egn'], Country::Bulgaria)
-            );
-        }
+        self::assertTrue($this->socrates->validateId($person['egn'], Country::Bulgaria));
+    }
 
-        foreach ($this->invalidIds as $egn) {
-            self::assertFalse(
-                $this->socrates->validateId($egn, Country::Bulgaria)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Bulgaria));
+    }
 
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('754201103', Country::Bulgaria);

--- a/tests/Feature/Europe/CroatiaTest.php
+++ b/tests/Feature/Europe/CroatiaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,109 +11,122 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class CroatiaTest extends FeatureTestCase
 {
-    private array $people;
-    private array $validIds;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->validIds = [
-            '34562345678',
-            '12286373446',
-            '97230458182',
-            '08214881054',
-            '27446063711'
-        ];
-
-        $this->people = [
+        return [
             'Ivana' => [
-                'jmbg' => '1809988305313',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1988-09-18'),
-                'age' => $this->calculateAge(new DateTime('1988-09-18')),
-                'pob' => 'Osijek, Slavonia region - Croatia'
+                'person' => [
+                    'jmbg' => '1809988305313',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1988-09-18'),
+                    'age' => self::calculateAge(new DateTime('1988-09-18')),
+                    'pob' => 'Osijek, Slavonia region - Croatia'
+                ],
             ],
             'Ana' => [
-                'jmbg' => '0808928315425',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1928-08-08'),
-                'age' => $this->calculateAge(new DateTime('1928-08-08')),
-                'pob' => 'Bjelovar, Virovitica, Koprivnica, Pakrac, Podravina region - Croatia'
+                'person' => [
+                    'jmbg' => '0808928315425',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1928-08-08'),
+                    'age' => self::calculateAge(new DateTime('1928-08-08')),
+                    'pob' => 'Bjelovar, Virovitica, Koprivnica, Pakrac, Podravina region - Croatia'
+                ],
             ],
             'Marija' => [
-                'jmbg' => '1106961359224',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1961-06-11'),
-                'age' => $this->calculateAge(new DateTime('1961-06-11')),
-                'pob' => 'Gospić, Lika region - Croatia'
+                'person' => [
+                    'jmbg' => '1106961359224',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1961-06-11'),
+                    'age' => self::calculateAge(new DateTime('1961-06-11')),
+                    'pob' => 'Gospić, Lika region - Croatia'
+                ],
             ],
             'Stjepan' => [
-                'jmbg' => '1105951323209',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1951-05-11'),
-                'age' => $this->calculateAge(new DateTime('1951-05-11')),
-                'pob' => 'Varaždin, Međimurje region - Croatia'
+                'person' => [
+                    'jmbg' => '1105951323209',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1951-05-11'),
+                    'age' => self::calculateAge(new DateTime('1951-05-11')),
+                    'pob' => 'Varaždin, Međimurje region - Croatia'
+                ],
             ],
             'Ivan' => [
-                'jmbg' => '2109971352638',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1971-09-21'),
-                'age' => $this->calculateAge(new DateTime('1971-09-21')),
-                'pob' => 'Gospić, Lika region - Croatia'
+                'person' => [
+                    'jmbg' => '2109971352638',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1971-09-21'),
+                    'age' => self::calculateAge(new DateTime('1971-09-21')),
+                    'pob' => 'Gospić, Lika region - Croatia'
+                ],
             ],
-        ];
-
-        $this->invalidIds = [
-            '2182791212638',
-            '27446182112',
-            '27446062711',
-            '1181818993013',
-            '1821992971638'
+            'unknown1' => [
+                'person' => [
+                    'oib' => '34562345678',
+                ],
+            ],
+            'unknown2' => [
+                'person' => [
+                    'oib' => '12286373446',
+                ],
+            ],
+            'unknown3' => [
+                'person' => [
+                    'oib' => '97230458182',
+                ],
+            ],
+            'unknown4' => [
+                'person' => [
+                    'oib' => '08214881054',
+                ],
+            ],
+            'unknown5' => [
+                'person' => [
+                    'oib' => '27446063711',
+                ]
+            ]
         ];
     }
 
-    public function test_extract_behaviour(): void
+    public static function invalidIdsDataProvider(): array
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['jmbg'], Country::Croatia);
+        return [
+            ['2182791212638'],
+            ['27446182112'],
+            ['27446062711'],
+            ['1181818993013'],
+            ['1821992971638'],
+        ];
+    }
 
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
+    {
+        if (isset($person['jmbg'])) {
+            $citizen = $this->socrates->getCitizenDataFromId($person['jmbg'], Country::Croatia);
             self::assertEquals($person['gender'], $citizen->getGender());
             self::assertEquals($person['dob'], $citizen->getDateOfBirth());
             self::assertEquals($person['age'], $citizen->getAge());
             self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+        } else {
+            $this->expectException(InvalidLengthException::class);
+            $citizen = $this->socrates->getCitizenDataFromId($person['oib'], Country::Croatia);
         }
-
-        $this->expectException(InvalidLengthException::class);
-
-        foreach ($this->validIds as $person) {
-            $this->socrates->getCitizenDataFromId($person, Country::Croatia);
-        }
-
-        $this->socrates->getCitizenDataFromId('1821992971', Country::Croatia);
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->validIds as $oib) {
-            self::assertTrue(
-                $this->socrates->validateId($oib, Country::Croatia)
-            );
-        }
+        self::assertTrue($this->socrates->validateId($person['jmbg'] ?? $person['oib'], Country::Croatia));
+    }
 
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['jmbg'], Country::Croatia)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Croatia));
+    }
 
-        foreach ($this->invalidIds as $jmbg) {
-            self::assertFalse(
-                $this->socrates->validateId($jmbg, Country::Croatia)
-            );
-        }
-
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('010597850', Country::Croatia);

--- a/tests/Feature/Europe/CzechRepublicTest.php
+++ b/tests/Feature/Europe/CzechRepublicTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,84 +11,86 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class CzechRepublicTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'Michal' => [
-                'rc' => '990224/9258',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1999-02-24'),
-                'age' => $this->calculateAge(new DateTime('1999-02-24')),
+                'person' => [
+                    'rc' => '990224/9258',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1999-02-24'),
+                    'age' => self::calculateAge(new DateTime('1999-02-24')),
+                ],
             ],
             'Tereza' => [
-                'rc' => '0157155328',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('2001-07-15'),
-                'age' => $this->calculateAge(new DateTime('2001-07-15')),
+                'person' => [
+                    'rc' => '0157155328',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('2001-07-15'),
+                    'age' => self::calculateAge(new DateTime('2001-07-15')),
+                ],
             ],
             'Adéla' => [
-                'rc' => '975406/2494',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1997-04-06'),
-                'age' => $this->calculateAge(new DateTime('1997-04-06')),
+                'person' => [
+                    'rc' => '975406/2494',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1997-04-06'),
+                    'age' => self::calculateAge(new DateTime('1997-04-06')),
+                ],
             ],
             'Lucie' => [
-                'rc' => '956022/6027',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1995-10-22'),
-                'age' => $this->calculateAge(new DateTime('1995-10-22')),
+                'person' => [
+                    'rc' => '956022/6027',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1995-10-22'),
+                    'age' => self::calculateAge(new DateTime('1995-10-22')),
+                ],
             ],
             'Petr' => [
-                'rc' => '960326/2955',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1996-03-26'),
-                'age' => $this->calculateAge(new DateTime('1996-03-26')),
+                'person' => [
+                    'rc' => '960326/2955',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1996-03-26'),
+                    'age' => self::calculateAge(new DateTime('1996-03-26')),
+                ],
             ],
         ];
+    }
 
-        $this->invalidIds = [
-            '010819/7762',
-            '715108/0998',
-            '960326/1297',
-            '995311/1928',
-            '886026/8751',
+    public static function invalidIdsDataProvider(): array
+    {
+        return [
+            ['010819/7762'],
+            ['715108/0998'],
+            ['960326/1297'],
+            ['995311/1928'],
+            ['886026/8751'],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['rc'], Country::CzechRepublic);
-
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-        }
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->validateId('88606/875', Country::CzechRepublic);
+        $citizen = $this->socrates->getCitizenDataFromId($person['rc'], Country::CzechRepublic);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['rc'], Country::CzechRepublic)
-            );
-        }
+        self::assertTrue($this->socrates->validateId($person['rc'], Country::CzechRepublic));
+    }
 
-        foreach ($this->invalidIds as $rc) {
-            self::assertFalse(
-                $this->socrates->validateId($rc, Country::CzechRepublic)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::CzechRepublic));
+    }
 
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('88606/875', Country::CzechRepublic);

--- a/tests/Feature/Europe/DenmarkTest.php
+++ b/tests/Feature/Europe/DenmarkTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,84 +11,86 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class DenmarkTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'julius' => [
-                'cpr' => '090792-1395',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1992-07-09'),
-                'age' => $this->calculateAge(new DateTime('1992-07-09')),
+                'person' => [
+                    'cpr' => '090792-1395',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1992-07-09'),
+                    'age' => self::calculateAge(new DateTime('1992-07-09')),
+                ],
             ],
             'naja' => [
-                'cpr' => '070593-0600',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1993-05-07'),
-                'age' => $this->calculateAge(new DateTime('1993-05-07')),
+                'person' => [
+                    'cpr' => '070593-0600',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1993-05-07'),
+                    'age' => self::calculateAge(new DateTime('1993-05-07')),
+                ],
             ],
             'rolla' => [
-                'cpr' => '150437-3068',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1937-04-15'),
-                'age' => $this->calculateAge(new DateTime('1937-04-15')),
+                'person' => [
+                    'cpr' => '150437-3068',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1937-04-15'),
+                    'age' => self::calculateAge(new DateTime('1937-04-15')),
+                ],
             ],
             'thomas' => [
-                'cpr' => '160888-1995',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1988-08-16'),
-                'age' => $this->calculateAge(new DateTime('1988-08-16')),
+                'person' => [
+                    'cpr' => '160888-1995',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1988-08-16'),
+                    'age' => self::calculateAge(new DateTime('1988-08-16')),
+                ],
             ],
             'mia' => [
-                'cpr' => '040404-7094',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('2004-04-04'),
-                'age' => $this->calculateAge(new DateTime('2004-04-04')),
+                'person' => [
+                    'cpr' => '040404-7094',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('2004-04-04'),
+                    'age' => self::calculateAge(new DateTime('2004-04-04')),
+                ],
             ],
         ];
+    }
 
-        $this->invalidIds = [
-            '234321-2454',
-            '333694-0034',
-            '088383-2313',
-            '133232-1323',
-            '040404-7054'
+    public static function invalidIdsDataProvider(): array
+    {
+        return [
+            ['234321-2454'],
+            ['333694-0034'],
+            ['088383-2313'],
+            ['133232-1323'],
+            ['040404-7054'],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['cpr'], Country::Denmark);
-
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-        }
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('324432-343', Country::Denmark);
+        $citizen = $this->socrates->getCitizenDataFromId($person['cpr'], Country::Denmark);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['cpr'], Country::Denmark)
-            );
-        }
+        self::assertTrue($this->socrates->validateId($person['cpr'], Country::Denmark));
+    }
 
-        foreach ($this->invalidIds as $cpr) {
-            self::assertFalse(
-                $this->socrates->validateId($cpr, Country::Denmark)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Denmark));
+    }
 
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('21442-2411', Country::Denmark);

--- a/tests/Feature/Europe/EstoniaTest.php
+++ b/tests/Feature/Europe/EstoniaTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,83 +11,86 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class EstoniaTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'Grete' => [
-                'ik' => '48004119745',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1980-04-11'),
-                'age' => $this->calculateAge(new DateTime('1980-04-11')),
+                'person' => [
+                    'ik' => '48004119745',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1980-04-11'),
+                    'age' => self::calculateAge(new DateTime('1980-04-11')),
+                ],
             ],
             'Kaarel' => [
-                'ik' => '50108040021',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('2001-08-04'),
-                'age' => $this->calculateAge(new DateTime('2001-08-04')),
+                'person' => [
+                    'ik' => '50108040021',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('2001-08-04'),
+                    'age' => self::calculateAge(new DateTime('2001-08-04')),
+                ],
             ],
             'Seb' => [
-                'ik' => '36910180118',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1969-10-18'),
-                'age' => $this->calculateAge(new DateTime('1969-10-18')),
+                'person' => [
+                    'ik' => '36910180118',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1969-10-18'),
+                    'age' => self::calculateAge(new DateTime('1969-10-18')),
+                ],
             ],
             'Jakob' => [
-                'ik' => '38601230129',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1986-01-23'),
-                'age' => $this->calculateAge(new DateTime('1986-01-23')),
+                'person' => [
+                    'ik' => '38601230129',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1986-01-23'),
+                    'age' => self::calculateAge(new DateTime('1986-01-23')),
+                ],
             ],
             'Katarina' => [
-                'ik' => '60310275631',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('2003-10-27'),
-                'age' => $this->calculateAge(new DateTime('2003-10-27')),
+                'person' => [
+                    'ik' => '60310275631',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('2003-10-27'),
+                    'age' => self::calculateAge(new DateTime('2003-10-27')),
+                ],
             ],
         ];
+    }
 
-        $this->invalidIds = [
-            '88732230129',
-            '12345630129',
-            '38608192637',
-            '10293846198',
-            '12309132708'
+    public static function invalidIdsDataProvider(): array
+    {
+        return [
+            ['88732230129'],
+            ['12345630129'],
+            ['38608192637'],
+            ['10293846198'],
+            ['12309132708'],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['ik'], Country::Estonia);
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-        }
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('3860123012', Country::Estonia);
+        $citizen = $this->socrates->getCitizenDataFromId($person['ik'], Country::Estonia);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['ik'], Country::Estonia)
-            );
-        }
+        self::assertTrue($this->socrates->validateId($person['ik'], Country::Estonia));
+    }
 
-        foreach ($this->invalidIds as $ik) {
-            self::assertFalse(
-                $this->socrates->validateId($ik, Country::Estonia)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Estonia));
+    }
 
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('6031027563', Country::Estonia);

--- a/tests/Feature/Europe/FinlandTest.php
+++ b/tests/Feature/Europe/FinlandTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,84 +11,86 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class FinlandTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'senja' => [
-                'hetu' => '040560-600E',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1960-05-04'),
-                'age' => $this->calculateAge(new DateTime('1960-05-04')),
+                'person' => [
+                    'hetu' => '040560-600E',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1960-05-04'),
+                    'age' => self::calculateAge(new DateTime('1960-05-04')),
+                ],
             ],
             'elias' => [
-                'hetu' => '121093-275N',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('1993-10-12'),
-                'age' => $this->calculateAge(new DateTime('1993-10-12')),
+                'person' => [
+                    'hetu' => '121093-275N',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('1993-10-12'),
+                    'age' => self::calculateAge(new DateTime('1993-10-12')),
+                ],
             ],
             'ida' => [
-                'hetu' => '260555-512H',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1955-05-26'),
-                'age' => $this->calculateAge(new DateTime('1955-05-26')),
+                'person' => [
+                    'hetu' => '260555-512H',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1955-05-26'),
+                    'age' => self::calculateAge(new DateTime('1955-05-26')),
+                ],
             ],
             'iiro' => [
-                'hetu' => '110416A479W',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('2016-04-11'),
-                'age' => $this->calculateAge(new DateTime('2016-04-11')),
+                'person' => [
+                    'hetu' => '110416A479W',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('2016-04-11'),
+                    'age' => self::calculateAge(new DateTime('2016-04-11')),
+                ],
             ],
             'stig' => [
-                'hetu' => '040403A2676',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('2003-04-04'),
-                'age' => $this->calculateAge(new DateTime('2003-04-04')),
-            ]
-        ];
-
-        $this->invalidIds = [
-            '050403+2676',
-            '110414-479W',
-            '653416A549B',
-            '122417-456T',
-            '121212A479F'
+                'person' => [
+                    'hetu' => '040403A2676',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('2003-04-04'),
+                    'age' => self::calculateAge(new DateTime('2003-04-04')),
+                ],
+            ],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    public static function invalidIdsDataProvider(): array
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['hetu'], Country::Finland);
-
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-        }
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('04403A2676', Country::Finland);
+        return [
+            ['050403+2676'],
+            ['110414-479W'],
+            ['653416A549B'],
+            ['122417-456T'],
+            ['121212A479F'],
+        ];
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['hetu'], Country::Finland)
-            );
-        }
+        $citizen = $this->socrates->getCitizenDataFromId($person['hetu'], Country::Finland);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
+    }
 
-        foreach ($this->invalidIds as $hetu) {
-            self::assertFalse(
-                $this->socrates->validateId($hetu, Country::Finland)
-            );
-        }
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
+    {
+        self::assertTrue($this->socrates->validateId($person['hetu'], Country::Finland));
+    }
 
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Finland));
+    }
+
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('21344-6451', Country::Finland);

--- a/tests/Feature/Europe/FranceTest.php
+++ b/tests/Feature/Europe/FranceTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,131 +11,146 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class FranceTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'Annette' => [
-                'insee' => '2820819398814 09',
-                'gender' => Gender::Female,
-                'dob' => DateTime::createFromFormat('Y-m', '1982-08'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1982-08')),
-                'pob' => 'Corrèze'
+                'person' => [
+                    'insee' => '2820819398814 09',
+                    'gender' => Gender::Female,
+                    'dob' => DateTime::createFromFormat('Y-m', '1982-08'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '1982-08')),
+                    'pob' => 'Corrèze',
+                ],
             ],
             'Lance' => [
-                'insee' => '1350455179061 16',
-                'gender' => Gender::Male,
-                'dob' => DateTime::createFromFormat('Y-m', '1935-04'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1935-04')),
-                'pob' => 'Meuse'
+                'person' => [
+                    'insee' => '1350455179061 16',
+                    'gender' => Gender::Male,
+                    'dob' => DateTime::createFromFormat('Y-m', '1935-04'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '1935-04')),
+                    'pob' => 'Meuse',
+                ],
             ],
             'Ancelote' => [
-                'insee' => '2381080214568 11',
-                'gender' => Gender::Female,
-                'dob' => DateTime::createFromFormat('Y-m', '1938-10'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1938-10')),
-                'pob' => 'Somme'
+                'person' => [
+                    'insee' => '2381080214568 11',
+                    'gender' => Gender::Female,
+                    'dob' => DateTime::createFromFormat('Y-m', '1938-10'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '1938-10')),
+                    'pob' => 'Somme',
+                ],
             ],
             'Lothair' => [
-                'insee' => '1880858704571 57',
-                'gender' => Gender::Male,
-                'dob' => DateTime::createFromFormat('Y-m', '1988-08'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1988-08')),
-                'pob' => 'Nièvre'
+                'person' => [
+                    'insee' => '1880858704571 57',
+                    'gender' => Gender::Male,
+                    'dob' => DateTime::createFromFormat('Y-m', '1988-08'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '1988-08')),
+                    'pob' => 'Nièvre',
+                ],
             ],
             'Millard' => [
-                'insee' => '1030307795669 72',
-                'gender' => Gender::Male,
-                'dob' => DateTime::createFromFormat('Y-m', '2003-03'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '2003-03')),
-                'pob' => 'Ardèche'
+                'person' => [
+                    'insee' => '1030307795669 72',
+                    'gender' => Gender::Male,
+                    'dob' => DateTime::createFromFormat('Y-m', '2003-03'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '2003-03')),
+                    'pob' => 'Ardèche',
+                ],
             ],
             'Geoffrey' => [
-                'insee' => '1820897401154 75',
-                'gender' => Gender::Male,
-                'dob' => DateTime::createFromFormat('Y-m', '1982-08'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1982-08')),
-                'pob' => 'Réunion'
+                'person' => [
+                    'insee' => '1820897401154 75',
+                    'gender' => Gender::Male,
+                    'dob' => DateTime::createFromFormat('Y-m', '1982-08'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '1982-08')),
+                    'pob' => 'Réunion',
+                ],
             ],
             'Galatee' => [
-                'insee' => '2041098718061 61',
-                'gender' => Gender::Female,
-                'dob' => DateTime::createFromFormat('Y-m', '2004-10'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '2004-10')),
-                'pob' => 'French Polynesia'
+                'person' => [
+                    'insee' => '2041098718061 61',
+                    'gender' => Gender::Female,
+                    'dob' => DateTime::createFromFormat('Y-m', '2004-10'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '2004-10')),
+                    'pob' => 'French Polynesia',
+                ],
             ],
             'Leal' => [
-                'insee' => '1103442505781 11',
-                'gender' => Gender::Male,
-                'dob' => DateTime::createFromFormat('Y-m', '2010-04'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '2010-04')),
-                'pob' => 'Loire'
+                'person' => [
+                    'insee' => '1103442505781 11',
+                    'gender' => Gender::Male,
+                    'dob' => DateTime::createFromFormat('Y-m', '2010-04'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '2010-04')),
+                    'pob' => 'Loire',
+                ],
             ],
             'Odelette' => [
-                'insee' => '2115028242370 20',
-                'gender' => Gender::Female,
-                'dob' => DateTime::createFromFormat('Y', '2011'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y', '2011')),
-                'pob' => 'Eure-et-Loir'
+                'person' => [
+                    'insee' => '2115028242370 20',
+                    'gender' => Gender::Female,
+                    'dob' => DateTime::createFromFormat('Y', '2011'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y', '2011')),
+                    'pob' => 'Eure-et-Loir',
+                ],
             ],
             'Roch' => [
-                'insee' => '199072A228070 10',
-                'gender' => Gender::Male,
-                'dob' => DateTime::createFromFormat('Y-m', '1999-07'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1999-07')),
-                'pob' => 'Corse-du-Sud'
+                'person' => [
+                    'insee' => '199072A228070 10',
+                    'gender' => Gender::Male,
+                    'dob' => DateTime::createFromFormat('Y-m', '1999-07'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '1999-07')),
+                    'pob' => 'Corse-du-Sud',
+                ],
             ],
             'Nadine' => [
-                'insee' => '257092B844458 87',
-                'gender' => Gender::Female,
-                'dob' => DateTime::createFromFormat('Y-m', '1957-09'),
-                'age' => $this->calculateAge(DateTime::createFromFormat('Y-m', '1957-09')),
-                'pob' => 'Haute-Corse'
-            ]
-        ];
-
-        $this->invalidIds = [
-            '1031629895669 72',
-            '2312763214568 54',
-            '1031622192811 22',
-            '2312763291021 11',
-            '2312760989812 01'
+                'person' => [
+                    'insee' => '257092B844458 87',
+                    'gender' => Gender::Female,
+                    'dob' => DateTime::createFromFormat('Y-m', '1957-09'),
+                    'age' => self::calculateAge(DateTime::createFromFormat('Y-m', '1957-09')),
+                    'pob' => 'Haute-Corse',
+                ],
+            ],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    public static function invalidIdsDataProvider(): array
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['insee'], Country::France);
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-            self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
-        }
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('10316221921 22', Country::France);
+        return [
+            ['1031629895669 72'],
+            ['2312763214568 54'],
+            ['1031622192811 22'],
+            ['2312763291021 11'],
+            ['2312760989812 01'],
+        ];
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['insee'], Country::France)
-            );
-        }
+        $citizen = $this->socrates->getCitizenDataFromId($person['insee'], Country::France);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
+        self::assertEquals($person['pob'], $citizen->getPlaceOfBirth());
+    }
 
-        foreach ($this->invalidIds as $insee) {
-            self::assertFalse(
-                $this->socrates->validateId($insee, Country::France)
-            );
-        }
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
+    {
+        self::assertTrue($this->socrates->validateId($person['insee'], Country::France));
+    }
 
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::France));
+    }
+
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('23127609898 01', Country::France);

--- a/tests/Feature/Europe/GermanyTest.php
+++ b/tests/Feature/Europe/GermanyTest.php
@@ -2,6 +2,7 @@
 
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
@@ -9,51 +10,80 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class GermanyTest extends FeatureTestCase
 {
-    private array $validIds;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function extractionDataProvider(): array
     {
-        parent::setUp();
-
-        $this->validIds = [
-            '81872495633',
-            '48954371207',
-            '55492670836',
-            '12345678995',
-            '11234567890'
+        return [
+            'unknown' => [
+                'person' => [
+                    'id' => '81872495633',
+                ],
+            ],
         ];
-
-        $this->invalidIds = [
-            '01234567812',
-            '81872495631',
-            '48954371206',
-            '55492670834',
-            '11234567899'
+    }
+    public static function peopleDataProvider(): array
+    {
+        return [
+            'unknown1' => [
+                'person' => [
+                    'id' => '81872495633',
+                ],
+            ],
+            'unknown2' => [
+                'person' => [
+                    'id' => '48954371207',
+                ],
+            ],
+            'unknown3' => [
+                'person' => [
+                    'id' => '55492670836',
+                ],
+            ],
+            'unknown4' => [
+                'person' => [
+                    'id' => '12345678995',
+                ],
+            ],
+            'unknown5' => [
+                'person' => [
+                    'id' => '11234567890',
+                ],
+            ],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    public static function invalidIdsDataProvider(): array
+    {
+        return [
+            ['01234567812'],
+            ['81872495631'],
+            ['48954371206'],
+            ['55492670834'],
+            ['11234567899'],
+        ];
+    }
+
+    #[DataProvider('extractionDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
         $this->expectException(UnsupportedOperationException::class);
 
-        $this->socrates->getCitizenDataFromId('81872495633', Country::Germany);
+        $this->socrates->getCitizenDataFromId($person['id'], Country::Germany);
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->validIds as $id) {
-            self::assertTrue(
-                $this->socrates->validateId($id, Country::Germany)
-            );
-        }
+        self::assertTrue($this->socrates->validateId($person['id'], Country::Germany));
+    }
 
-        foreach ($this->invalidIds as $invalidId) {
-            self::assertFalse(
-                $this->socrates->validateId($invalidId, Country::Germany)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Germany));
+    }
 
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('0123456789', Country::Germany);

--- a/tests/Feature/Europe/GreeceTest.php
+++ b/tests/Feature/Europe/GreeceTest.php
@@ -2,6 +2,7 @@
 
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Exceptions\UnsupportedOperationException;
@@ -9,54 +10,88 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class GreeceTest extends FeatureTestCase
 {
-    private array $validIds;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function extractionDataProvider(): array
     {
-        parent::setUp();
-
-        $this->validIds = [
-            'ΔΞ-891728',
-            'ΚΦ-012734',
-            'ΖΜ-431981',
-            'ΒΠ-018621',
-            'ΩΗ-877612',
-            'ΑΜ-811664',
-        ];
-
-        $this->invalidIds = [
-            'Δx-091003',
-            'Ω-1213312',
-            'ΒΖΜ-98912',
-            'ΧΘ-543971',
-            'ΛΨ-087125',
-            'ΑΜ-81A13I',
-            '12-123123',
+        return [
+            'unknown' => [
+                'person' => [
+                    'id' => 'ΔΞ-891728',
+                ],
+            ],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    public static function peopleDataProvider(): array
+    {
+        return [
+            'unknown1' => [
+                'person' => [
+                    'id' => 'ΔΞ-891728',
+                ],
+            ],
+            'unknown2' => [
+                'person' => [
+                    'id' => 'ΚΦ-012734',
+                ],
+            ],
+            'unknown3' => [
+                'person' => [
+                    'id' => 'ΖΜ-431981',
+                ],
+            ],
+            'unknown4' => [
+                'person' => [
+                    'id' => 'ΒΠ-018621',
+                ],
+            ],
+            'unknown5' => [
+                'person' => [
+                    'id' => 'ΩΗ-877612',
+                ],
+            ],
+            'unknown6' => [
+                'person' => [
+                    'id' => 'ΑΜ-811664',
+                ],
+            ],
+        ];
+    }
+
+    public static function invalidIdsDataProvider(): array
+    {
+        return [
+            ['Δx-091003'],
+            ['Ω-1213312'],
+            ['ΒΖΜ-98912'],
+            ['ΧΘ-543971'],
+            ['ΛΨ-087125'],
+            ['ΑΜ-81A13I'],
+            ['12-123123'],
+        ];
+    }
+
+    #[DataProvider('extractionDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
         $this->expectException(UnsupportedOperationException::class);
 
-        $this->socrates->getCitizenDataFromId('ΔΞ-891728', Country::Greece);
+        $this->socrates->getCitizenDataFromId($person['id'], Country::Greece);
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->validIds as $id) {
-            self::assertTrue(
-                $this->socrates->validateId($id, Country::Greece)
-            );
-        }
+        self::assertTrue($this->socrates->validateId($person['id'], Country::Greece));
+    }
 
-        foreach ($this->invalidIds as $invalidId) {
-            self::assertFalse(
-                $this->socrates->validateId($invalidId, Country::Greece)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Greece));
+    }
 
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('ΔΞ-89172', Country::Greece);

--- a/tests/Feature/Europe/HungaryTest.php
+++ b/tests/Feature/Europe/HungaryTest.php
@@ -3,6 +3,7 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Constants\Gender;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
@@ -10,77 +11,80 @@ use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class HungaryTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'Aliz' => [
-                'pin' => '2-720216-1673',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1972-02-16'),
-                'age' => $this->calculateAge(new DateTime('1972-02-16')),
+                'person' => [
+                    'pin' => '2-720216-1673',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1972-02-16'),
+                    'age' => self::calculateAge(new DateTime('1972-02-16')),
+                ],
             ],
             'Dora' => [
-                'pin' => '2-690609-5528',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1969-06-09'),
-                'age' => $this->calculateAge(new DateTime('1969-06-09')),
+                'person' => [
+                    'pin' => '2-690609-5528',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1969-06-09'),
+                    'age' => self::calculateAge(new DateTime('1969-06-09')),
+                ],
             ],
             'Jolan' => [
-                'pin' => '2-840320-0414',
-                'gender' => Gender::Female,
-                'dob' => new DateTime('1984-03-20'),
-                'age' => $this->calculateAge(new DateTime('1984-03-20')),
+                'person' => [
+                    'pin' => '2-840320-0414',
+                    'gender' => Gender::Female,
+                    'dob' => new DateTime('1984-03-20'),
+                    'age' => self::calculateAge(new DateTime('1984-03-20')),
+                ],
             ],
             'Kapolcs' => [
-                'pin' => '3-101010-5646',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('2010-10-10'),
-                'age' => $this->calculateAge(new DateTime('2010-10-10')),
+                'person' => [
+                    'pin' => '3-101010-5646',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('2010-10-10'),
+                    'age' => self::calculateAge(new DateTime('2010-10-10')),
+                ],
             ],
             'Vincze' => [
-                'pin' => '3-080321-8523',
-                'gender' => Gender::Male,
-                'dob' => new DateTime('2008-03-21'),
-                'age' => $this->calculateAge(new DateTime('2008-03-21')),
+                'person' => [
+                    'pin' => '3-080321-8523',
+                    'gender' => Gender::Male,
+                    'dob' => new DateTime('2008-03-21'),
+                    'age' => self::calculateAge(new DateTime('2008-03-21')),
+                ],
             ],
         ];
-
-        $this->invalidIds = [];
     }
 
-    public function test_extract_behaviour(): void
+    public static function invalidIdsDataProvider(): array
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['pin'], Country::Hungary);
-            self::assertEquals($person['gender'], $citizen->getGender());
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-        }
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('26905528', Country::Hungary);
+        return [];
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['pin'], Country::Hungary)
-            );
-        }
+        $citizen = $this->socrates->getCitizenDataFromId($person['pin'], Country::Hungary);
+        self::assertEquals($person['gender'], $citizen->getGender());
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
+    }
 
-        foreach ($this->invalidIds as $pin) {
-            self::assertFalse(
-                $this->socrates->validateId($pin, Country::Bulgaria)
-            );
-        }
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
+    {
+        self::assertTrue($this->socrates->validateId($person['pin'], Country::Hungary));
+    }
 
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Hungary));
+    }
+
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('26905528', Country::Hungary);

--- a/tests/Feature/Europe/IcelandTest.php
+++ b/tests/Feature/Europe/IcelandTest.php
@@ -3,84 +3,87 @@
 namespace Reducktion\Socrates\Tests\Feature\Europe;
 
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Reducktion\Socrates\Constants\Country;
 use Reducktion\Socrates\Exceptions\InvalidLengthException;
 use Reducktion\Socrates\Tests\Feature\FeatureTestCase;
 
 class IcelandTest extends FeatureTestCase
 {
-    private array $people;
-    private array $invalidIds;
-
-    protected function setUp(): void
+    public static function peopleDataProvider(): array
     {
-        parent::setUp();
-
-        $this->people = [
+        return [
             'andi' => [
-                'kt' => '0902862349',
-                'dob' => new DateTime('1986-02-09'),
-                'age' => $this->calculateAge(new DateTime('1986-02-09')),
+                'person' => [
+                    'kt' => '0902862349',
+                    'dob' => new DateTime('1986-02-09'),
+                    'age' => self::calculateAge(new DateTime('1986-02-09')),
+                ],
             ],
             'freyja' => [
-                'kt' => '120174-3399',
-                'dob' => new DateTime('1974-01-12'),
-                'age' => $this->calculateAge(new DateTime('1974-01-12')),
+                'person' => [
+                    'kt' => '120174-3399',
+                    'dob' => new DateTime('1974-01-12'),
+                    'age' => self::calculateAge(new DateTime('1974-01-12')),
+                ],
             ],
             'nair' => [
-                'kt' => '1808905059',
-                'dob' => new DateTime('1990-08-18'),
-                'age' => $this->calculateAge(new DateTime('1990-08-18')),
+                'person' => [
+                    'kt' => '1808905059',
+                    'dob' => new DateTime('1990-08-18'),
+                    'age' => self::calculateAge(new DateTime('1990-08-18')),
+                ],
             ],
             'eva' => [
-                'kt' => '2008108569',
-                'dob' => new DateTime('1910-08-20'),
-                'age' => $this->calculateAge(new DateTime('1910-08-20')),
+                'person' => [
+                    'kt' => '2008108569',
+                    'dob' => new DateTime('1910-08-20'),
+                    'age' => self::calculateAge(new DateTime('1910-08-20')),
+                ],
             ],
             'hrafn' => [
-                'kt' => '100303-4930',
-                'dob' => new DateTime('2003-03-10'),
-                'age' => $this->calculateAge(new DateTime('2003-03-10')),
+                'person' => [
+                    'kt' => '100303-4930',
+                    'dob' => new DateTime('2003-03-10'),
+                    'age' => self::calculateAge(new DateTime('2003-03-10')),
+                ],
             ],
         ];
+    }
 
-        $this->invalidIds = [
-            '2343212454',
-            '333694-0034',
-            '1201743389',
-            '0902862549',
-            '0404047054'
+    public static function invalidIdsDataProvider(): array
+    {
+        return [
+            ['2343212454'],
+            ['333694-0034'],
+            ['1201743389'],
+            ['0902862549'],
+            ['0404047054'],
         ];
     }
 
-    public function test_extract_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_extract_behaviour(array $person): void
     {
-        foreach ($this->people as $person) {
-            $citizen = $this->socrates->getCitizenDataFromId($person['kt'], Country::Iceland);
-
-            self::assertEquals($person['dob'], $citizen->getDateOfBirth());
-            self::assertEquals($person['age'], $citizen->getAge());
-        }
-
-        $this->expectException(InvalidLengthException::class);
-
-        $this->socrates->getCitizenDataFromId('324432-343', Country::Iceland);
+        $citizen = $this->socrates->getCitizenDataFromId($person['kt'], Country::Iceland);
+        self::assertEquals($person['dob'], $citizen->getDateOfBirth());
+        self::assertEquals($person['age'], $citizen->getAge());
     }
 
-    public function test_validation_behaviour(): void
+    #[DataProvider('peopleDataProvider')]
+    public function test_validation_with_valid_ids_passes(array $person): void
     {
-        foreach ($this->people as $person) {
-            self::assertTrue(
-                $this->socrates->validateId($person['kt'], Country::Iceland)
-            );
-        }
+        self::assertTrue($this->socrates->validateId($person['kt'], Country::Iceland));
+    }
 
-        foreach ($this->invalidIds as $kt) {
-            self::assertFalse(
-                $this->socrates->validateId($kt, Country::Iceland)
-            );
-        }
+    #[DataProvider('invalidIdsDataProvider')]
+    public function test_validation_with_invalid_ids_fails(string $invalidId): void
+    {
+        self::assertFalse($this->socrates->validateId($invalidId, Country::Iceland));
+    }
 
+    public function test_validation_using_ids_with_invalid_length_throw_exception(): void
+    {
         $this->expectException(InvalidLengthException::class);
 
         $this->socrates->validateId('21442411', Country::Iceland);

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -17,12 +17,16 @@ abstract class FeatureTestCase extends TestCase
         $this->socrates = new Socrates();
     }
 
-    abstract public function test_extract_behaviour(): void;
+    abstract public function test_extract_behaviour(array $person): void;
 
-    abstract public function test_validation_behaviour(): void;
+    abstract public function test_validation_with_valid_ids_passes(array $person): void;
 
-    public function calculateAge(DateTime $dateOfBirth): int
+    abstract public function test_validation_with_invalid_ids_fails(string $invalidId): void;
+
+    abstract public function test_validation_using_ids_with_invalid_length_throw_exception(): void;
+
+    public static function calculateAge(DateTime $dateOfBirth): int
     {
-        return (new DateTime())->diff($dateOfBirth)->y;
+        return new DateTime()->diff($dateOfBirth)->y;
     }
 }


### PR DESCRIPTION
Changelist:

- Adjust parent test method: add parameters for data providers; split validation test; `calculateAge` is now static
- Change `getAge` method to return `null` instead of throwing an exception when the DoB is `null`
- Update all tests
  - [x] Albania
  - [x] Belgium
  - [x] Bosnia Herzegovina
  - [x] Bulgaria
  - [x] Croatia
  - [x] Czech Republic
  - [x] Denmark
  - [x] Estonia
  - [x] Finland
  - [x] France
  - [x] Germany
  - [x] Greece
  - [x] Hungary
  - [x] Iceland
  - [ ] ...